### PR TITLE
Fill data and selection for production orders screen

### DIFF
--- a/Application.mxml
+++ b/Application.mxml
@@ -9,9 +9,9 @@
         <!-- define data models -->
         <s:ArrayCollection id="orders">
             <fx:Object po="PO‑001" qty="1000" machine="M‑XYZ‑001" operator="John Doe"
-                       start="08:00 AM" end="-" status="IN PROGRESS"/>
+                       start="08:00 AM" end="-" status="IN PROGRESS" progress="45%"/>
             <fx:Object po="PO‑002" qty="500" machine="M‑ABC‑002" operator="Jane Smith"
-                       start="07:30 AM" end="11:00 AM" status="COMPLETED"/>
+                       start="07:30 AM" end="11:00 AM" status="COMPLETED" progress="100%"/>
             <!-- add more rows as needed -->
         </s:ArrayCollection>
         <s:ArrayCollection id="machines">
@@ -20,7 +20,19 @@
             <fx:String>M‑ABC‑002</fx:String>
             <fx:String>M‑DEF‑003</fx:String>
         </s:ArrayCollection>
-        <!-- similar arrays for operators/statuses -->
+        <s:ArrayCollection id="operators">
+            <fx:String>All Operators</fx:String>
+            <fx:String>John Doe</fx:String>
+            <fx:String>Jane Smith</fx:String>
+            <fx:String>Michael Brown</fx:String>
+        </s:ArrayCollection>
+        <s:ArrayCollection id="statuses">
+            <fx:String>All Statuses</fx:String>
+            <fx:String>PENDING</fx:String>
+            <fx:String>IN PROGRESS</fx:String>
+            <fx:String>COMPLETED</fx:String>
+            <fx:String>ON HOLD</fx:String>
+        </s:ArrayCollection>
     </fx:Declarations>
 
     <!-- Global styles -->
@@ -105,7 +117,9 @@
                              dropShadowVisible="true" cornerRadius="8">
                         <s:DataGrid id="ordersGrid" dataProvider="{orders}" width="100%" height="100%"
                                     alternatingRowColors="[0xFFFFFF, 0xF7FAFC]"
-                                    selectionMode="singleRow">
+                                    selectionMode="singleRow"
+                                    selectedIndex="0"
+                                    selectionChange="ordersGrid_selectionChange(event)">
                             <s:columns>
                                 <s:ArrayCollection>
                                     <s:GridColumn dataField="po"   headerText="PO#" />
@@ -204,7 +218,7 @@
         import spark.events.GridSelectionEvent;
         import mx.collections.ArrayCollection;
 
-        [Bindable] private var selectedOrder:Object = {};
+        [Bindable] private var selectedOrder:Object = orders.getItemAt(0);
 
         protected function handleAssign(order:Object):void {
             // TODO: implement assignment logic


### PR DESCRIPTION
## Summary
- add operators and statuses lists for filter dropdowns
- include progress data and initial selection in orders table
- handle order selection changes

## Testing
- `mxmlc Application.mxml` *(fails: command not found)*
- `apt-cache search mxmlc | head -n 20` *(no packages found)*

------
https://chatgpt.com/codex/tasks/task_e_68937439c0a08327bacebbab6765cf7e